### PR TITLE
[권새롬] Sprint22 스프린트 미션 3

### DIFF
--- a/css/join.css
+++ b/css/join.css
@@ -173,3 +173,52 @@ aside.easy_log img {
     text-decoration: underline;
     color: var(--blue);
 }
+
+/* ========================================
+   반응형 스타일 (Responsive Styles)
+   ======================================== */
+
+/* Tablet: 768px 이상 ~ 1199px 이하 - PC와 동일한 디자인 유지 */
+@media (min-width: 768px) and (max-width: 1199px) {
+    /* Tablet 사이즈에서도 PC와 동일한 디자인 유지 */
+    input {
+        width: 640px;
+    }
+    
+    aside.easy_log {
+        width: 640px;
+    }
+}
+
+/* Mobile: 375px 이상 ~ 767px 이하 */
+@media (min-width: 375px) and (max-width: 767px) {
+    .login-container {
+        padding: 60px 16px;
+        align-items: stretch;
+    }
+    
+    form {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+    }
+    
+    input {
+        width: 100%;
+        max-width: 400px;
+    }
+    
+    aside.easy_log {
+        width: 100%;
+        max-width: 400px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    
+    .signup_link {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        text-align: center;
+    }
+}

--- a/css/login.css
+++ b/css/login.css
@@ -173,3 +173,52 @@ aside.easy_log img {
     text-decoration: underline;
     color: var(--blue);
 }
+
+/* ========================================
+   반응형 스타일 (Responsive Styles)
+   ======================================== */
+
+/* Tablet: 768px 이상 ~ 1199px 이하 - PC와 동일한 디자인 유지 */
+@media (min-width: 768px) and (max-width: 1199px) {
+    /* Tablet 사이즈에서도 PC와 동일한 디자인 유지 */
+    input {
+        width: 640px;
+    }
+    
+    aside.easy_log {
+        width: 640px;
+    }
+}
+
+/* Mobile: 375px 이상 ~ 767px 이하 */
+@media (min-width: 375px) and (max-width: 767px) {
+    .login-container {
+        padding: 60px 16px;
+        align-items: stretch;
+    }
+    
+    form {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+    }
+    
+    input {
+        width: 100%;
+        max-width: 400px;
+    }
+    
+    aside.easy_log {
+        width: 100%;
+        max-width: 400px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    
+    .signup_link {
+        width: 100%;
+        max-width: 400px;
+        margin: 0 auto;
+        text-align: center;
+    }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -198,72 +198,10 @@ footer > ul:nth-child(1) li:nth-child(1) {
    반응형 스타일 (Responsive Styles)
    ======================================== */
 
-/* 1920px 미만 - Large Desktop */
-@media (max-width: 1919px) {
+/* Tablet: 768px 이상 ~ 1199px 이하 */
+@media (min-width: 768px) and (max-width: 1199px) {
     header nav {
-        padding: 0 200px;
-    }
-}
-
-/* 1440px 미만 - Desktop */
-@media (max-width: 1439px) {
-    header nav {
-        padding: 0 100px;
-    }
-    
-    header img {
-        width: 140px;
-    }
-    
-    .hero-content h1 {
-        font-size: 36px;
-        margin-bottom: 28px;
-    }
-    
-    .hero-btn {
-        padding: 14px 100px;
-        font-size: 18px;
-    }
-    
-    .hero-image img {
-        width: 450px;
-    }
-    
-    .hero-inner {
-        gap: 30px;
-    }
-    
-    main ul {
-        margin: 100px 0;
-        gap: 30px;
-    }
-    
-    article ul li h2 {
-        font-size: 36px;
-        margin-bottom: 20px;
-    }
-    
-    article ul li p {
-        font-size: 20px;
-    }
-    
-    .con1 ul li:nth-child(2),
-    .con2 ul li:nth-child(1),
-    .con3 ul li:nth-child(2) {
-        padding: 50px;
-        height: 380px;
-    }
-    
-    footer > ul:nth-child(1) {
-        padding-top: 30px;
-        padding-bottom: 80px;
-    }
-}
-
-/* 1024px 미만 - Tablet Landscape */
-@media (max-width: 1023px) {
-    header nav {
-        padding: 0 50px;
+        padding: 0 24px;
     }
     
     header img {
@@ -344,14 +282,14 @@ footer > ul:nth-child(1) li:nth-child(1) {
     }
 }
 
-/* 768px 미만 - Tablet Portrait */
-@media (max-width: 767px) {
+/* Mobile: 375px 이상 ~ 767px 이하 */
+@media (min-width: 375px) and (max-width: 767px) {
     header {
         padding: 8px 0;
     }
     
     header nav {
-        padding: 0 24px;
+        padding: 0 16px;
     }
     
     header img {
@@ -453,66 +391,3 @@ footer > ul:nth-child(1) li:nth-child(1) {
     }
 }
 
-/* 480px 미만 - Mobile */
-@media (max-width: 479px) {
-    header nav {
-        padding: 0 16px;
-    }
-    
-    header img {
-        width: 80px;
-    }
-    
-    header nav .login-btn {
-        padding: 6px 16px;
-        font-size: 12px;
-    }
-    
-    .hero {
-        padding: 20px 12px 0 12px;
-        padding-top: 70px;
-    }
-    
-    .hero-content h1 {
-        font-size: 20px;
-        margin-bottom: 16px;
-    }
-    
-    .hero-btn {
-        padding: 10px 40px;
-        font-size: 14px;
-    }
-    
-    .hero-image img {
-        width: 220px;
-    }
-    
-    main ul {
-        margin: 40px 0;
-        padding: 0 16px;
-    }
-    
-    article ul li > .blue_txt {
-        font-size: 12px;
-    }
-    
-    article ul li h2 {
-        font-size: 20px;
-        margin-bottom: 10px;
-    }
-    
-    article ul li p {
-        font-size: 13px;
-    }
-    
-    .con1 ul li:nth-child(2),
-    .con2 ul li:nth-child(1),
-    .con3 ul li:nth-child(2) {
-        padding: 24px 16px;
-    }
-    
-    footer > ul:nth-child(1) {
-        padding: 24px 16px 40px;
-        gap: 16px;
-    }
-}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>판다마켓</title>
+        
+        <!-- Open Graph / Facebook -->
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://pandamarket.com/" />
+        <meta property="og:title" content="판다 마켓" />
+        <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
+        <meta property="og:image" content="https://pandamarket.com/img/hero-panda.png" />
+        
+        <!-- Twitter -->
+        <meta property="twitter:card" content="summary_large_image" />
+        <meta property="twitter:url" content="https://pandamarket.com/" />
+        <meta property="twitter:title" content="판다 마켓" />
+        <meta property="twitter:description" content="일상의 모든 물건을 거래해보세요" />
+        <meta property="twitter:image" content="https://pandamarket.com/img/hero-panda.png" />
+        
         <link rel="stylesheet" href="/css/reset.css" />
         <link rel="stylesheet" href="/css/main.css" />
         <link


### PR DESCRIPTION
## 진행한 미션 버전
<!-- [ ] 사이에 x 표시를 해주세요. e.g., [x] -->
<!-- 더 많은 마크다운 문법은 아래 링크를 참고해 주세요. -->
<!-- https://www.heropy.dev/p/B74sNE -->
- [x] 초급 (Ver 1)
- [ ] 중급 (Ver 2)

---

## 미션 요구사항
<!-- 미션 요구사항을 채운 후, 구현한 부분을 x 표시 해주세요. -->
<!-- e.g., - [x] '로그인'버튼 클릭 시 로그인 페이지('/login')로 이동합니다 (빈 페이지) -->
<!-- 심화를 진행하지 않은 경우에는 제거해 주세요. -->
### 기본

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

- [x] 랜딩 페이지
Tablet 사이즈로 작아질 때 "판다마켓" 로고의 왼쪽에 여백 24px, "로그인" 버튼 오른쪽 여백 24px을 유지할 수 있도록 "판다마켓" 로고와 "로그인" 버튼의 간격이 가까워집니다.
Mobile 사이즈로 작아질 때 "판다마켓" 로고의 왼쪽에 여백 16px, "로그인" 버튼 오른쪽 여백 16px을 유지할 수 있도록 "판다마켓" 로고와 "로그인" 버튼의 간격이 가까워집니다.
화면 영역이 줄어들면 "Privacy Policy", "FAQ", "codeit-2024"이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

- [x] 로그인, 회원가입 페이지 공통
Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화
- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지("/") 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 "판다 마켓", 설명은 "일상의 모든 물건을 거래해보세요"로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.

---

## 주요 변경사항 및 학습 포인트

- 반응형 디자인 적용: PC(1200px+), Tablet(768px~1199px), Mobile(375px~767px) 브레이크포인트 설정 및 각 사이즈별 스타일 조정
- SNS 공유 최적화: Open Graph와 Twitter Card 메타 태그 추가로 페이스북, 카카오톡 등에서 미리보기 표시
- 반응형 레이아웃 기법: min-width/max-width 조합, width: 100%와 max-width로 유연한 반응형 구현

---

## 주강사에게

**집중적으로 봐줬으면 하는 부분**

- 없습니다.

**해결하지 못한 문제 / 궁금한 점**

- 없습니다.
